### PR TITLE
ビルド失敗時に issue を作成する処理を実装

### DIFF
--- a/.github/workflows/lake_build_result.yml
+++ b/.github/workflows/lake_build_result.yml
@@ -39,6 +39,8 @@ jobs:
         id: test-step
         with:
           lake_package_directory: './Test/BuildFail'
+          # issue 作成は行わないようにする
+          on_update_fails: 'silent'
 
       - name: assert output
         if: steps.test-step.outputs.lake_build_result != 'failure'

--- a/Action.lean
+++ b/Action.lean
@@ -7,8 +7,6 @@ import Action.RunCmd
 import Action.TryBuild
 import Action.Notify
 
-def issueTitle := "ビルド失敗"
-
 /-- エントリーポイント -/
 public def main (_ : List String) : IO UInt32 := do
   let isLakePackage ← detectLakePackage

--- a/Action.lean
+++ b/Action.lean
@@ -5,6 +5,7 @@ import Action.DetectLakePackage
 import Action.Input
 import Action.RunCmd
 import Action.TryBuild
+import Action.Notify
 
 def issueTitle := "ビルド失敗"
 
@@ -15,10 +16,8 @@ public def main (_ : List String) : IO UInt32 := do
     IO.println "指定されたディレクトリはlakeパッケージではありません。"
     return 1
 
-  let buildResult ← tryBuild
-
-  match buildResult with
-  | .failure errorMsg => GH.createIssue issueTitle errorMsg
-  | .success => pure ()
+  let result ← tryBuild
+  let way ← Input.on_update_fails
+  notify way result
 
   return 0

--- a/Action.lean
+++ b/Action.lean
@@ -1,9 +1,12 @@
 module
 
+import Action.GH.CreateIssue
 import Action.DetectLakePackage
 import Action.Input
 import Action.RunCmd
 import Action.TryBuild
+
+def issueTitle := "ビルド失敗"
 
 /-- エントリーポイント -/
 public def main (_ : List String) : IO UInt32 := do
@@ -12,9 +15,10 @@ public def main (_ : List String) : IO UInt32 := do
     IO.println "指定されたディレクトリはlakeパッケージではありません。"
     return 1
 
-  let _ ← tryBuild
+  let buildResult ← tryBuild
 
-  -- gh コマンドがインストールできているか確認する
-  let _ ← runCmd #["gh", "--version"] none
+  match buildResult with
+  | .failure errorMsg => GH.createIssue issueTitle errorMsg
+  | .success => pure ()
 
   return 0

--- a/Action/DetectLakePackage.lean
+++ b/Action/DetectLakePackage.lean
@@ -5,7 +5,7 @@ import Action.Output
 
 /-- 入力で指定されたディレクトリがlakeパッケージであるか判定する -/
 public def detectLakePackage : IO Bool := do
-  let lakePackageDirectory ← Input.lakePackageDirectory
+  let lakePackageDirectory ← Input.lake_package_directory
   let toolchainPath : System.FilePath := lakePackageDirectory / "lean-toolchain"
   let lakePackageExists ← toolchainPath.pathExists
   setOutput "lake_package_exists" (toString lakePackageExists)

--- a/Action/GH/CreateIssue.lean
+++ b/Action/GH/CreateIssue.lean
@@ -1,0 +1,16 @@
+module
+
+import Action.RunCmd
+
+namespace GH
+
+/-- `gh issue create` で issue を作成する -/
+public def createIssue (title body : String) : IO Unit := do
+  match (← IO.getEnv "GITHUB_REPOSITORY") with
+  | some repo =>
+    let _ ← runCmd #["gh", "issue", "create", "--repo", repo, "--title", title, "--body", body] none
+    pure ()
+  | none =>
+    throw <| IO.userError "環境変数 GITHUB_REPOSITORY が設定されていません。"
+
+end GH

--- a/Action/Input.lean
+++ b/Action/Input.lean
@@ -14,9 +14,27 @@ protected def get (name : String) : IO String := do
     throw <| IO.userError s!"入力 '{name}' が渡されていません。"
 
 /-- 更新するべきLakeパッケージが存在するディレクトリ。 -/
-protected def lakePackageDirectory : IO FilePath := do
+protected def lake_package_directory : IO FilePath := do
   let dirStr ← Input.get "lake_package_directory"
   return FilePath.mk dirStr
+
+/-- ユーザへの通知方法 -/
+inductive WayToNotify where
+  /-- issue を作成する -/
+  | issue
+  /-- 通知しない -/
+  | silent
+export WayToNotify (issue silent)
+
+/-- 更新後のチェックが失敗した場合にどのようにしてユーザに通知するか。 -/
+protected def on_update_fails : IO WayToNotify := do
+  let way ← Input.get "on_update_fails"
+  if way = "issue" then
+    return WayToNotify.issue
+  else if way = "silent" then
+    return WayToNotify.silent
+  else
+    throw <| IO.userError s!"on_update_fails に不正な入力値 '{way}' が渡されました。"
 
 end
 

--- a/Action/Notify.lean
+++ b/Action/Notify.lean
@@ -1,0 +1,17 @@
+module
+
+public import Action.Input
+public import Action.TryBuild
+import Action.GH.CreateIssue
+
+open Input
+
+/-- ビルド結果に基づいてユーザに通知を出す -/
+public def notify (way : WayToNotify) (result : BuildResult) : IO Unit := do
+  match way with
+  | .silent => pure ()
+  | .issue =>
+    match result with
+    | .success => pure ()
+    | .failure errorMsg =>
+      GH.createIssue "ビルド失敗" errorMsg

--- a/Action/TryBuild.lean
+++ b/Action/TryBuild.lean
@@ -16,11 +16,16 @@ public def BuildResult.isFailure : BuildResult → Bool
   | .success => false
   | .failure _ => true
 
+/-- ビルドが成功したかどうか -/
+public def BuildResult.isSuccess : BuildResult → Bool
+  | .success => true
+  | .failure _ => false
+
 /-- `lake build` を試みる -/
 public def tryBuild : IO BuildResult := do
-  let lakePackageDirectory ← Input.lakePackageDirectory
+  let dir ← Input.lake_package_directory
   try
-    let _ ← runCmd #["lake", "build"] (cwd := lakePackageDirectory)
+    let _ ← runCmd #["lake", "build"] (cwd := dir)
     setOutput "lake_build_result" "success"
     return BuildResult.success
   catch e =>

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,18 @@ inputs:
     description: 更新するべきLakeパッケージが存在するディレクトリ。
     required: false
     default: "."
+  on_update_fails:
+    description: |
+      更新後のチェックが失敗した場合にどのようにしてユーザに通知するか。
+      取りうる値:
+      * issue: 更新失敗を通知する issue を作成する。
+      * silent: 通知しない。
+    required: false
+    default: "issue"
   token:
     description: |
       gh コマンドを使用するための GitHub トークン。
+      基本的にデフォルト値のままで問題ない。
     required: false
     default: ${{ github.token }}
 
@@ -27,5 +36,6 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.lake_package_directory }}
+    - ${{ inputs.on_update_fails }}
   env:
     GH_TOKEN: ${{ inputs.token }}

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,11 @@ inputs:
     description: 更新するべきLakeパッケージが存在するディレクトリ。
     required: false
     default: "."
+  token:
+    description: |
+      gh コマンドを使用するための GitHub トークン。
+    required: false
+    default: ${{ github.token }}
 
 outputs:
   lake_package_exists:
@@ -22,3 +27,5 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.lake_package_directory }}
+  env:
+    GH_TOKEN: ${{ inputs.token }}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -8,7 +8,7 @@ package "Action" where
 
 @[default_target]
 lean_lib «Action» where
-  globs := #[.submodules `Action]
+  globs := #[.submodules `Action, .one `Action]
 
 lean_exe action where
   root := `Action


### PR DESCRIPTION
### タスクリスト

* [ ] ビルド失敗時に issue を投稿する機能の実装
* [ ] issue 投稿テストワークフローの作成 (workflow の permission を write にするのを忘れないようにね)
* [ ] issue 投稿テストワークフローに対して、邪魔にならないように投稿された issue を自動でクローズする機能の追加